### PR TITLE
feat: support globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,20 @@ Note the following scenarios:
 
 - If you completely delete a line, the operations will be canceled.
 - If you rename multiple files with the exact same name, the last one will take over and the previous ones will be deleted.
+- If you are deeply renaming paths and have renamed the a shared base directory, you need to update other related paths accordingly.
 
 &nbsp;
 
 ## Options
 
-| Argument   | Description                                                            |
-| ---------- | ---------------------------------------------------------------------- |
-| `--dry`    | Prints the output to the console without actually applying the changes |
-| `--silent` | Prevents from printing to the console                                  |
+| Argument          | Description                                                            |
+| ----------------- | ---------------------------------------------------------------------- |
+| `--dry`           | Prints the output to the console without actually applying the changes |
+| `--silent`        | Prevents from printing to the console                                  |
+| `--dirs`          | Only match directories                                                 |
+| `--files`         | Only match files                                                       |
+| `--base <dir>`    | Defines the base directory in which the rename will be performed       |
+| `--depth <depth>` | Defines the maximum depth in case a globstar is used (`**`)            |
 
 &nbsp;
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "dev": "yarn build && node ./dist/index.js",
+    "dev": "yarn build -- --watch",
     "build": "tsup src/index.ts --format cjs,esm --dts-resolve",
     "test": "jest --passWithNoTests",
     "prepublishOnly": "npm run build"
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "cac": "^6.7.3",
+    "fast-glob": "^3.2.7",
     "kleur": "^4.1.4",
     "temp-dir": "^2.0.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,19 @@
 import createInterface from 'cac'
 import { startRenameProcess } from './rename'
 import { readFile } from 'fs/promises'
-import { invoke, findDirectory } from './utils'
+import { invoke } from './utils'
 import { logger } from './logger'
 
 invoke(async () => {
 	const { version } = JSON.parse(await readFile(new URL('../package.json', import.meta.url), { encoding: 'utf-8' }))
 	const cli = createInterface('renamer')
-		.option('-d, --dry', 'Do not actually apply the changes', { default: false })
+		.option('-D, --dry', 'Do not actually apply the changes', { default: false })
 		.option('-s, --silent', 'Do not write on the standard output', { default: false })
-		.usage('[directory] [...options]')
+		.option('-d, --dirs, --dir', 'Only match directories', { default: false })
+		.option('-f, --files, --file', 'Only match files', { default: false })
+		.option('-b, --base <directory>', 'Base directory in which to search', { default: process.cwd() })
+		.option('--depth <depth>', 'Specify the maximum depth when using a globstar')
+		.usage('[match] [...options]')
 		.version(version)
 		.help()
 
@@ -21,12 +25,20 @@ invoke(async () => {
 		return process.exit(0)
 	}
 
+	if (options.files && options.dirs) {
+		logger.error(new Error('You cannot use both --files and --dirs.'))
+	}
+
 	logger.options({ silent: options.silent })
 
 	try {
 		await startRenameProcess({
-			directory: await findDirectory(args[0]),
+			glob: args[0],
+			directory: options.base,
+			onlyDirectories: options.dirs,
+			onlyFiles: options.files,
 			silent: options.silent,
+			depth: options.depth,
 			dry: options.dry,
 		})
 	} catch (error) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -45,6 +45,17 @@ export class Logger {
 	}
 
 	/**
+	 * Logs an information.
+	 */
+	info(message: string) {
+		if (!this.shouldPrint()) {
+			return
+		}
+
+		console.log(`${prefix(yellow('info'))} ${message}`)
+	}
+
+	/**
 	 * Logs an error.
 	 */
 	error(error: Error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { access } from 'fs/promises'
-import { resolve } from 'path'
 
 export async function invoke(fn: Function, handleError?: (error: Error) => void) {
 	try {
@@ -9,20 +8,15 @@ export async function invoke(fn: Function, handleError?: (error: Error) => void)
 	}
 }
 
-export function tap<T>(value: T, callback: (value: T) => void): T {
-	callback(value)
+export async function tap<T>(value: T, callback: (value: T) => Promise<void>): Promise<T> {
+	await callback(value)
 	return value
 }
 
-export async function findDirectory(directory: string) {
-	if (!directory?.length) {
-		return process.cwd()
-	}
-
+export async function ensureExists(path: string) {
 	try {
-		await access(resolve(directory))
-		return resolve(directory)
-	} catch {
-		throw new Error(`Can not access ${directory}.`)
+		await access(path)
+	} catch (error) {
+		throw new Error(`Could not access ${path}.`)
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,7 +1190,7 @@ expect@^27.0.6:
     jest-message-util "^27.0.6"
     jest-regex-util "^27.0.6"
 
-fast-glob@^3.1.1:
+fast-glob@^3.1.1, fast-glob@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==


### PR DESCRIPTION
This PR enables the glob syntax for better control over which files and directories are being renamed. 

Changes: 
- The `[directory]` option (first argument) moved to a `--base <dir>` option
- The first argument is now a glob powered by [`fast-glob`](https://github.com/mrmlnc/fast-glob)
- `--dirs` allows to select only directories
- `--files` allows to select only files
- `--depth <depth>` defines the maximum depth (default is without limit, so be careful with globs)

Additional logic had to be implemented to handle cases where parent paths were renamed or deleted. 

For instance, in the following tree, if `deep` was renamed and `deep/test3.txt` was renamed as well, `rn` would crash because it would not find the initial path, since it would have been renamed: 

```
deep
test1.txt
test2.txt
deep/test3.txt
deep/test4.txt
```

Because of that, every path is checked against previous operations: 
- If the current path has a deleted parent directory, the operation is not performed (expected behavior).
- If the current path has a renamed parent directory, it is renamed accordingly prior to the operation.

---

Closes #2 
Closes #3
Closes #4